### PR TITLE
eng-1862: Upgrade to actions/setup-java@v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
       uses: Codesee-io/codesee-detect-languages-action@main
 
     - name: Configure JDK 16
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       if: ${{ fromJSON(steps.detect-languages.outputs.languages).java }}
       with:
         java-version: "16"


### PR DESCRIPTION
This version of `actions/setup-java` uses
`@actions/core` v1.10.0, which will not trigger warnings for deprecated `set-output` usage:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#patching-your-actions-and-workflows