### PR TITLE
eng-1860: Prepare for `v2` release of workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A [composite GitHub action](https://docs.github.com/en/actions/creating-actions/
         continue-on-error: true
         name: Analyse the repo with CodeSee
         steps:
-          - uses: Codesee-io/codesee-action@main
+          - uses: Codesee-io/codesee-action@v2
             with:
               codesee-token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
    ```

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Detect Languages
       id: detect-languages
-      uses: Codesee-io/codesee-detect-languages-action@main
+      uses: Codesee-io/codesee-detect-languages-action@latest
 
     - name: Configure JDK 16
       uses: actions/setup-java@v3
@@ -61,7 +61,7 @@ runs:
 
     - name: Generate Map
       id: generate-map
-      uses: Codesee-io/codesee-map-action@main
+      uses: Codesee-io/codesee-map-action@latest
       with:
         step: map
         api_token: ${{ inputs.codesee-token }}
@@ -70,7 +70,7 @@ runs:
 
     - name: Upload Map
       id: upload-map
-      uses: Codesee-io/codesee-map-action@main
+      uses: Codesee-io/codesee-map-action@latest
       with:
         step: mapUpload
         api_token: ${{ inputs.codesee-token }}
@@ -78,7 +78,7 @@ runs:
 
     - name: Insights
       id: insights
-      uses: Codesee-io/codesee-map-action@main
+      uses: Codesee-io/codesee-map-action@latest
       with:
         step: insights
         api_token: ${{ inputs.codesee-token }}


### PR DESCRIPTION
Fix up the branches we reference in `README.md` and
the workflow itself in preparation for the official release
of the `v2` tag.