### PR TITLE
Use node 18 for javascript and kotlin (tree-sitter)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,12 @@ runs:
         distribution: "zulu"
 
       # CodeSee Maps Go support uses a static binary so there's no setup step required.
-    - name: Configure Node.js 16
+      
+    - name: Configure Node.js 18
       uses: actions/setup-node@v3
-      if: ${{ fromJSON(steps.detect-languages.outputs.languages).javascript }}
+      if: ${{ fromJSON(steps.detect-languages.outputs.languages).javascript || fromJSON(steps.detect-languages.outputs.languages).kotlin }}
       with:
-        node-version: "16"
+        node-version: "18"
 
     - name: Configure Python 3.x
       uses: actions/setup-python@v4


### PR DESCRIPTION
Because of the tree-sitter node bindings and the github action environment, we have to install node 18.x before calling the CLI with `npx`