### PR TITLE
Support a custom CodeSee service URL

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         distribution: "zulu"
 
       # CodeSee Maps Go support uses a static binary so there's no setup step required.
-      
+
     - name: Configure Node.js 18
       uses: actions/setup-node@v3
       if: ${{ fromJSON(steps.detect-languages.outputs.languages).javascript || fromJSON(steps.detect-languages.outputs.languages).kotlin }}
@@ -69,7 +69,7 @@ runs:
 
     - name: Generate Map
       id: generate-map
-      uses: Codesee-io/codesee-map-action@latest
+      uses: Codesee-io/codesee-map-action@staging
       with:
         step: map
         api_token: ${{ inputs.codesee-token }}
@@ -78,7 +78,7 @@ runs:
 
     - name: Upload Map
       id: upload-map
-      uses: Codesee-io/codesee-map-action@latest
+      uses: Codesee-io/codesee-map-action@staging
       with:
         step: mapUpload
         api_token: ${{ inputs.codesee-token }}
@@ -86,7 +86,7 @@ runs:
 
     - name: Insights
       id: insights
-      uses: Codesee-io/codesee-map-action@latest
+      uses: Codesee-io/codesee-map-action@staging
       with:
         step: insights
         api_token: ${{ inputs.codesee-token }}

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   codesee-token:
     description: "The value of CODESEE_ARCH_DIAG_API_TOKEN"
     required: true
-  codesee-service-url:
+  codesee-url:
     description: "The URL to Codesee service"
     required: false
 
@@ -72,28 +72,28 @@ runs:
 
     - name: Generate Map
       id: generate-map
-      uses: Codesee-io/codesee-map-action@staging
+      uses: Codesee-io/codesee-map-action@latest
       with:
         step: map
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
         languages: ${{ steps.detect-languages.outputs.languages }}
-        insights_service_url: ${{ inputs.codesee-service-url }}
+        codesee_url: ${{ inputs.codesee-url }}
 
     - name: Upload Map
       id: upload-map
-      uses: Codesee-io/codesee-map-action@staging
+      uses: Codesee-io/codesee-map-action@latest
       with:
         step: mapUpload
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
-        insights_service_url: ${{ inputs.codesee-service-url }}
+        codesee_url: ${{ inputs.codesee-url }}
 
     - name: Insights
       id: insights
-      uses: Codesee-io/codesee-map-action@staging
+      uses: Codesee-io/codesee-map-action@latest
       with:
         step: insights
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
-        insights_service_url: ${{ inputs.codesee-service-url }}
+        codesee_url: ${{ inputs.codesee-url }}

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
   codesee-token:
     description: "The value of CODESEE_ARCH_DIAG_API_TOKEN"
     required: true
+  codesee-service-url:
+    description: "The URL to Codesee service"
+    required: false
 
 runs:
   using: "composite"
@@ -75,6 +78,7 @@ runs:
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
         languages: ${{ steps.detect-languages.outputs.languages }}
+        insights_service_url: ${{ inputs.codesee-service-url }}
 
     - name: Upload Map
       id: upload-map
@@ -83,6 +87,7 @@ runs:
         step: mapUpload
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
+        insights_service_url: ${{ inputs.codesee-service-url }}
 
     - name: Insights
       id: insights
@@ -91,3 +96,4 @@ runs:
         step: insights
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
+        insights_service_url: ${{ inputs.codesee-service-url }}


### PR DESCRIPTION
Added a new input optional: `codesee-url`. This allow for a custom installation of CodeSee, helpful to set up a new environment (ex: test / staging). 

This depends on: https://github.com/Codesee-io/codesee-map-action/pull/58/files