### PR TITLE
ENG-2743: fix Github CI deprecated message for set-output on rust-toolchain

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,10 +58,8 @@ runs:
 
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       if: ${{ fromJSON(steps.detect-languages.outputs.languages).rust }}
-      with:
-        toolchain: stable
 
     - name: Configure .NET SDK 7
       uses: actions/setup-dotnet@v3


### PR DESCRIPTION
Migrated from the unmaintained repo "actions-rs/toolchain@v1" => "dtolnay/rust-toolchain@stable" that contains the fix for new Github output approach. 