### PR TITLE
Testing GHES support for the codesee-map-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,12 +65,12 @@ runs:
       uses: actions/setup-dotnet@v3
       if: ${{ fromJSON(steps.detect-languages.outputs.languages).dot-net }}
       with:
-        dotnet-version: '7.x'
-        dotnet-quality: 'ga'
+        dotnet-version: "7.x"
+        dotnet-quality: "ga"
 
     - name: Generate Map
       id: generate-map
-      uses: Codesee-io/codesee-map-action@latest
+      uses: Codesee-io/codesee-map-action@c637373f8ae3c001d362d7147bd5f0a51e56b73f
       with:
         step: map
         api_token: ${{ inputs.codesee-token }}
@@ -80,7 +80,7 @@ runs:
 
     - name: Upload Map
       id: upload-map
-      uses: Codesee-io/codesee-map-action@latest
+      uses: Codesee-io/codesee-map-action@c637373f8ae3c001d362d7147bd5f0a51e56b73f
       with:
         step: mapUpload
         api_token: ${{ inputs.codesee-token }}
@@ -89,7 +89,7 @@ runs:
 
     - name: Insights
       id: insights
-      uses: Codesee-io/codesee-map-action@latest
+      uses: Codesee-io/codesee-map-action@c637373f8ae3c001d362d7147bd5f0a51e56b73f
       with:
         step: insights
         api_token: ${{ inputs.codesee-token }}


### PR DESCRIPTION
I added support for GHES in the `codesee-map-action` repo: https://github.com/Codesee-io/codesee-map-action/pull/61.

This PR points the `codesee-action` to the commit in the PR above to verify that it works as intended.