### PR TITLE
Set --max-old-space-size so node has more heap size to work with

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ runs:
         github_ref: ${{ github.ref }}
         languages: ${{ steps.detect-languages.outputs.languages }}
         codesee_url: ${{ inputs.codesee-url }}
-        NODE_OPTIONS: --max-old-space-size=4096
+        NODE_OPTIONS: --max-old-space-size=6144
 
     - name: Upload Map
       id: upload-map
@@ -83,7 +83,7 @@ runs:
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
         codesee_url: ${{ inputs.codesee-url }}
-        NODE_OPTIONS: --max-old-space-size=4096
+        NODE_OPTIONS: --max-old-space-size=6144
 
     - name: Insights
       id: insights
@@ -94,4 +94,4 @@ runs:
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
         codesee_url: ${{ inputs.codesee-url }}
-        NODE_OPTIONS: --max-old-space-size=4096
+        NODE_OPTIONS: --max-old-space-size=6144

--- a/action.yml
+++ b/action.yml
@@ -72,6 +72,7 @@ runs:
         github_ref: ${{ github.ref }}
         languages: ${{ steps.detect-languages.outputs.languages }}
         codesee_url: ${{ inputs.codesee-url }}
+        NODE_OPTIONS: --max-old-space-size=4096
 
     - name: Upload Map
       id: upload-map
@@ -82,6 +83,7 @@ runs:
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
         codesee_url: ${{ inputs.codesee-url }}
+        NODE_OPTIONS: --max-old-space-size=4096
 
     - name: Insights
       id: insights
@@ -92,3 +94,4 @@ runs:
         api_token: ${{ inputs.codesee-token }}
         github_ref: ${{ github.ref }}
         codesee_url: ${{ inputs.codesee-url }}
+        NODE_OPTIONS: --max-old-space-size=4096


### PR DESCRIPTION
By setting the `NODE_OPTIONS` env var, the map steps will now have 4GB of memory to work with.

We are using `NODE_OPTIONS` so that any spawned node process will have this same heap size available.

GitHub runners have 7GB of memory (or more), so this should be safely below any limit that would lead to thrashing.