### PR TITLE
Allow github.com token to avoid rate limit in GHES environments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
   codesee-url:
     description: "The URL to Codesee service"
     required: false
+  github-com-token:
+    description: "A personal GitHub token to avoid rate limits from unauthenticated requests"
 
 runs:
   using: "composite"
@@ -49,7 +51,7 @@ runs:
       with:
         python-version: "3.x"
         architecture: "x64"
-        token:
+        token: ${{ inputs.github-com-token }}
 
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@ inputs:
     required: false
   github-com-token:
     description: "A personal GitHub token to avoid rate limits from unauthenticated requests"
+    required: false
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "The URL to Codesee service"
     required: false
   github-com-token:
-    description: "A personal GitHub token to avoid rate limits from unauthenticated requests"
+    description: "A personal GitHub.com token to avoid rate limits due to unauthenticated requests from GHES environments. See https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#avoiding-rate-limit-issues"
     required: false
 
 runs:
@@ -31,6 +31,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: "18"
+        token: ${{ inputs.github-com-token }}
 
     - name: Detect Languages
       id: detect-languages

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
       with:
         python-version: "3.x"
         architecture: "x64"
+        token:
 
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable


### PR DESCRIPTION
New optional param `github-com-token` can be provided and if so is used when setting up node and python toolchains.

This avoids issues wrt rate limiting in GHES environments. See [actions/setup-python docs](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#avoiding-rate-limit-issues) to learn more.