### PR TITLE
Skip installing specific language toolchains for self-hosted runner environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,27 @@ A [composite GitHub action](https://docs.github.com/en/actions/creating-actions/
 
 1. Copy the following template into your new workflow file:
 
-    ```yaml
-    on:
-      push:
-        branches:
-          - main
-      pull_request_target:
-        types: [opened, synchronize, reopened]
+   ```yaml
+   on:
+     push:
+       branches:
+         - main
+     pull_request_target:
+       types: [opened, synchronize, reopened]
 
-    name: CodeSee
+   name: CodeSee
 
-    permissions: read-all
+   permissions: read-all
 
-    jobs:
-      codesee:
-        runs-on: ubuntu-latest
-        continue-on-error: true
-        name: Analyse the repo with CodeSee
-        steps:
-          - uses: Codesee-io/codesee-action@v2
-            with:
-              codesee-token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
+   jobs:
+     codesee:
+       runs-on: ubuntu-latest
+       continue-on-error: true
+       name: Analyse the repo with CodeSee
+       steps:
+         - uses: Codesee-io/codesee-action@v2
+           with:
+             codesee-token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
    ```
 
 1. Commit the new workflow to GitHub.
@@ -40,7 +40,9 @@ A [composite GitHub action](https://docs.github.com/en/actions/creating-actions/
 
 ## Skip installing packages on every run
 
-If you run on a self hosted-runner, it might be more efficient to not installing packages everytime you run this action by skipping them.
+If you run on a self hosted-runner, it might be more efficient to skip installing packages everytime you run this action.
+Set the `lang-setup` input to 'none' to skip all language setup.
+If you want to skip most languages but still want the action to install node and .net (for example), make a comma-separated list: `lang-setup: "node, .net"`
 
 ```
 jobs:
@@ -52,9 +54,5 @@ jobs:
       - uses: Codesee-io/codesee-action@v2
         with:
           codesee-token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
-          skip-installing-node: true
-          skip-installing-jdk: true
-          skip-installing-rust: true
-          skip-installing-python: true
-          skip-installing-dotnet: true
+          lang-setup: 'none'
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [composite GitHub action](https://docs.github.com/en/actions/creating-actions/
 ## How to use this action
 
 1. Define a new action in your repository by adding a file in the `.github/workflows/` directory. For example:
-  
+
    ```shell
    touch .github/workflows/codesee.yml
    ```
@@ -37,3 +37,24 @@ A [composite GitHub action](https://docs.github.com/en/actions/creating-actions/
 
 1. Commit the new workflow to GitHub.
 1. That's it! CodeSee will analyze your code to keep your visualizations up to date.
+
+## Skip installing packages on every run
+
+If you run on a self hosted-runner, it might be more efficient to not installing packages everytime you run this action by skipping them.
+
+```
+jobs:
+  codesee:
+    runs-on: self-hosted
+    continue-on-error: true
+    name: Analyse the repo with CodeSee
+    steps:
+      - uses: Codesee-io/codesee-action@v2
+        with:
+          codesee-token: ${{ secrets.CODESEE_ARCH_DIAG_API_TOKEN }}
+          skip-installing-node: true
+          skip-installing-jdk: true
+          skip-installing-rust: true
+          skip-installing-python: true
+          skip-installing-dotnet: true
+```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ A [composite GitHub action](https://docs.github.com/en/actions/creating-actions/
 ## Skip installing packages on every run
 
 If you run on a self hosted-runner, it might be more efficient to skip installing packages everytime you run this action.
-Set the `lang-setup` input to 'none' to skip all language setup.
-If you want to skip most languages but still want the action to install node and .net (for example), make a comma-separated list: `lang-setup: "node, .net"`
+
+### The `lang-setup` input variable
+
+- By default, `lang-setup` is set to 'all', and this action will setup whichever language toolchains it believes are needed.
+- Set the `lang-setup` input to 'none' to skip all language setup. But beware! Node is required for the action to run. If you do not have node configured in your runner environment, you'll need to use the more specific option below.
+- If you want to skip most languages but still want the action to install specific language toolchains, make a comma-separated list. For example, for node and .net, `lang-setup: "node, .net"`. The complete list of language toolchains: node, python, jdk, rust, .net. All other language analysis is run using the node toolchain.
 
 ```
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Configure Python 3.x
       uses: actions/setup-python@v4
-      if: ${{ (inputs.lang-setup == 'all' || contains(inputs.lang-setup, 'jdk')) && fromJSON(steps.detect-languages.outputs.languages).python }}
+      if: ${{ (inputs.lang-setup == 'all' || contains(inputs.lang-setup, 'python')) && fromJSON(steps.detect-languages.outputs.languages).python }}
       with:
         python-version: "3.x"
         architecture: "x64"

--- a/action.yml
+++ b/action.yml
@@ -12,26 +12,10 @@ inputs:
   codesee-url:
     description: "The URL to Codesee service"
     required: false
-  skip-installing-node:
-    description: "Should action skip installing Node?"
+  lang-setup:
+    description: "Which language toolchains should we install? Accepted values: 'all', 'none', or a comma separated list of languages: 'node, python, jdk, .net, rust'"
     required: false
-    default: 'false'
-  skip-installing-jdk:
-    description: "Should action skip installing JDK?"
-    required: false
-    default: 'false'
-  skip-installing-rust:
-    description: "Should action skip installing Rust?"
-    required: false
-    default: 'false'
-  skip-installing-python:
-    description: "Should action skip installing Python?"
-    required: false
-    default: 'false'
-  skip-installing-dotnet:
-    description: "Should action skip installing .NET?"
-    required: false
-    default: 'false'
+    default: "all"
 
 runs:
   using: "composite"
@@ -48,7 +32,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: "18"
-      if: ${{ inputs.skip-installing-node == 'false' }}
+      if: ${{ inputs.lang-setup == 'all' || contains(inputs.lang-setup, 'node') }}
 
     - name: Detect Languages
       id: detect-languages
@@ -57,7 +41,7 @@ runs:
 
     - name: Configure JDK 16
       uses: actions/setup-java@v3
-      if: ${{ inputs.skip-installing-jdk == 'false' && fromJSON(steps.detect-languages.outputs.languages).java }}
+      if: ${{ (inputs.lang-setup == 'all' || contains(inputs.lang-setup, 'jdk')) && fromJSON(steps.detect-languages.outputs.languages).java }}
       with:
         java-version: "16"
         distribution: "zulu"
@@ -66,7 +50,7 @@ runs:
 
     - name: Configure Python 3.x
       uses: actions/setup-python@v4
-      if: ${{ inputs.skip-installing-python == 'false' && fromJSON(steps.detect-languages.outputs.languages).python }}
+      if: ${{ (inputs.lang-setup == 'all' || contains(inputs.lang-setup, 'jdk')) && fromJSON(steps.detect-languages.outputs.languages).python }}
       with:
         python-version: "3.x"
         architecture: "x64"
@@ -74,11 +58,11 @@ runs:
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable
       uses: dtolnay/rust-toolchain@stable
-      if: ${{ inputs.skip-installing-rust == 'false' && fromJSON(steps.detect-languages.outputs.languages).rust }}
+      if: ${{ (inputs.lang-setup == 'all' || contains(inputs.lang-setup, 'rust')) && fromJSON(steps.detect-languages.outputs.languages).rust }}
 
     - name: Configure .NET SDK 7
       uses: actions/setup-dotnet@v3
-      if: ${{ inputs.skip-installing-dotnet == 'false' && fromJSON(steps.detect-languages.outputs.languages).dot-net }}
+      if: ${{ (inputs.lang-setup == 'all' || contains(inputs.lang-setup, '.net')) && fromJSON(steps.detect-languages.outputs.languages).dot-net }}
       with:
         dotnet-version: "7.x"
         dotnet-quality: "ga"

--- a/action.yml
+++ b/action.yml
@@ -15,28 +15,23 @@ inputs:
   skip-installing-node:
     description: "Should action skip installing Node?"
     required: false
-    type: boolean
-    default: false
+    default: 'false'
   skip-installing-jdk:
     description: "Should action skip installing JDK?"
     required: false
-    type: boolean
-    default: false
+    default: 'false'
   skip-installing-rust:
     description: "Should action skip installing Rust?"
     required: false
-    type: boolean
-    default: false
+    default: 'false'
   skip-installing-python:
     description: "Should action skip installing Python?"
     required: false
-    type: boolean
-    default: false
+    default: 'false'
   skip-installing-dotnet:
     description: "Should action skip installing .NET?"
     required: false
-    type: boolean
-    default: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -53,7 +48,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: "18"
-      if: ${{ !inputs.skip-installing-node }}
+      if: ${{ inputs.skip-installing-node == 'false' }}
 
     - name: Detect Languages
       id: detect-languages
@@ -62,7 +57,7 @@ runs:
 
     - name: Configure JDK 16
       uses: actions/setup-java@v3
-      if: ${{ !inputs.skip-installing-jdk && fromJSON(steps.detect-languages.outputs.languages).java }}
+      if: ${{ inputs.skip-installing-jdk == 'false' && fromJSON(steps.detect-languages.outputs.languages).java }}
       with:
         java-version: "16"
         distribution: "zulu"
@@ -71,7 +66,7 @@ runs:
 
     - name: Configure Python 3.x
       uses: actions/setup-python@v4
-      if: ${{ !inputs.skip-installing-python && fromJSON(steps.detect-languages.outputs.languages).python }}
+      if: ${{ inputs.skip-installing-python == 'false' && fromJSON(steps.detect-languages.outputs.languages).python }}
       with:
         python-version: "3.x"
         architecture: "x64"
@@ -79,11 +74,11 @@ runs:
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable
       uses: dtolnay/rust-toolchain@stable
-      if: ${{ !inputs.skip-installing-rust && fromJSON(steps.detect-languages.outputs.languages).rust }}
+      if: ${{ inputs.skip-installing-rust == 'false' && fromJSON(steps.detect-languages.outputs.languages).rust }}
 
     - name: Configure .NET SDK 7
       uses: actions/setup-dotnet@v3
-      if: ${{ !inputs.skip-installing-dotnet && fromJSON(steps.detect-languages.outputs.languages).dot-net }}
+      if: ${{ inputs.skip-installing-dotnet == 'false' && fromJSON(steps.detect-languages.outputs.languages).dot-net }}
       with:
         dotnet-version: "7.x"
         dotnet-quality: "ga"

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,31 @@ inputs:
   codesee-url:
     description: "The URL to Codesee service"
     required: false
+  skip-installing-node:
+    description: "Should action skip installing Node?"
+    required: false
+    type: boolean
+    default: false
+  skip-installing-jdk:
+    description: "Should action skip installing JDK?"
+    required: false
+    type: boolean
+    default: false
+  skip-installing-rust:
+    description: "Should action skip installing Rust?"
+    required: false
+    type: boolean
+    default: false
+  skip-installing-python:
+    description: "Should action skip installing Python?"
+    required: false
+    type: boolean
+    default: false
+  skip-installing-dotnet:
+    description: "Should action skip installing .NET?"
+    required: false
+    type: boolean
+    default: false
 
 runs:
   using: "composite"
@@ -28,6 +53,7 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version: "18"
+      if: ${{ !inputs.skip-installing-node }}
 
     - name: Detect Languages
       id: detect-languages
@@ -40,6 +66,7 @@ runs:
       with:
         java-version: "16"
         distribution: "zulu"
+      if: ${{ !inputs.skip-installing-jdk }}
 
       # CodeSee Maps Go support uses a static binary so there's no setup step required.
 
@@ -49,11 +76,13 @@ runs:
       with:
         python-version: "3.x"
         architecture: "x64"
+      if: ${{ !inputs.skip-installing-python }}
 
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable
       uses: dtolnay/rust-toolchain@stable
       if: ${{ fromJSON(steps.detect-languages.outputs.languages).rust }}
+      if: ${{ !inputs.skip-installing-rust }}
 
     - name: Configure .NET SDK 7
       uses: actions/setup-dotnet@v3
@@ -61,6 +90,7 @@ runs:
       with:
         dotnet-version: "7.x"
         dotnet-quality: "ga"
+      if: ${{ !inputs.skip-installing-dotnet }}
 
     - name: Generate Map
       id: generate-map

--- a/action.yml
+++ b/action.yml
@@ -62,35 +62,31 @@ runs:
 
     - name: Configure JDK 16
       uses: actions/setup-java@v3
-      if: ${{ fromJSON(steps.detect-languages.outputs.languages).java }}
+      if: ${{ !inputs.skip-installing-jdk && fromJSON(steps.detect-languages.outputs.languages).java }}
       with:
         java-version: "16"
         distribution: "zulu"
-      if: ${{ !inputs.skip-installing-jdk }}
 
       # CodeSee Maps Go support uses a static binary so there's no setup step required.
 
     - name: Configure Python 3.x
       uses: actions/setup-python@v4
-      if: ${{ fromJSON(steps.detect-languages.outputs.languages).python }}
+      if: ${{ !inputs.skip-installing-python && fromJSON(steps.detect-languages.outputs.languages).python }}
       with:
         python-version: "3.x"
         architecture: "x64"
-      if: ${{ !inputs.skip-installing-python }}
 
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable
       uses: dtolnay/rust-toolchain@stable
-      if: ${{ fromJSON(steps.detect-languages.outputs.languages).rust }}
-      if: ${{ !inputs.skip-installing-rust }}
+      if: ${{ !inputs.skip-installing-rust && fromJSON(steps.detect-languages.outputs.languages).rust }}
 
     - name: Configure .NET SDK 7
       uses: actions/setup-dotnet@v3
-      if: ${{ fromJSON(steps.detect-languages.outputs.languages).dot-net }}
+      if: ${{ !inputs.skip-installing-dotnet && fromJSON(steps.detect-languages.outputs.languages).dot-net }}
       with:
         dotnet-version: "7.x"
         dotnet-quality: "ga"
-      if: ${{ !inputs.skip-installing-dotnet }}
 
     - name: Generate Map
       id: generate-map


### PR DESCRIPTION
This PR introduces a new setting: `lang-setup` to control what languages should be installed on during the action run. 