### PR TITLE
Try using our own fork of rust-toolchain.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -57,7 +57,7 @@ runs:
 
     # We need the rust toolchain because it uses rustc and cargo to inspect the package
     - name: Configure Rust 1.x stable
-      uses: dtolnay/rust-toolchain@stable
+      uses: Codesee-io/rust-toolchain@stable
       if: ${{ (inputs.lang-setup == 'all' || contains(inputs.lang-setup, 'rust')) && fromJSON(steps.detect-languages.outputs.languages).rust }}
 
     - name: Configure .NET SDK 7


### PR DESCRIPTION
So, dtolnay's version runs into issues with it not having Verified Creator status on the marketplace. Some users can't run our action because dtolnay/rust-toolchain is not considered "safe". But a CodeSee fork sidesteps this issue!

I've tested this and verified that github will happily run this version of the action: https://github.com/jleven/freeCodeCamp/actions/runs/6305702759