### PR TITLE
Add concurrency setting to prevent multiple actions on the same branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ A [composite GitHub action](https://docs.github.com/en/actions/creating-actions/
        types: [opened, synchronize, reopened]
 
    name: CodeSee
+   concurrency:
+     group: ${{ github.head_ref || github.run_id}}
+     cancel-in-progress: true
 
    permissions: read-all
 


### PR DESCRIPTION
Since CodeSee actions take a while to run, we should check to see if there is an action instance running on a branch and cancel it if a new commit comes in.